### PR TITLE
[Prompt optimizatoion] Use part of prompt for first lines of file

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,0 +1,2 @@
+// Proportion of lines from the beginning of the file in the prompt
+export const LEADING_LINES_PROP = 0.15;


### PR DESCRIPTION
Hi there!

In this commit i propose to fill first 15% of the prompt by first lines of current file.

In the vast majority of cases the first lines of a file contain more valuable imformation for the AI than the average lines. For instance - file docstring, imports of other modules, etc.
Especially imported modules in most languages can be a huge hint for AI on what kind of code developer is writing and which functions & objects are better to use.

PS: I'm currently working on a more advanced pompt generation (i hope something useful will turn out later), but it looks like this one is already valuable enough to contribute.
